### PR TITLE
Allow users to delete their own roles

### DIFF
--- a/supabase/migrations/20250829120000_add_user_roles_delete_policy.sql
+++ b/supabase/migrations/20250829120000_add_user_roles_delete_policy.sql
@@ -1,0 +1,4 @@
+-- Allow users to delete their own roles
+CREATE POLICY "Users can delete their own roles"
+  ON public.user_roles FOR DELETE
+  USING (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- allow authenticated users to delete rows from `user_roles` table when `auth.uid() = user_id`

## Testing
- `npx supabase db reset` *(fails: 403 Forbidden - GET https://registry.npmjs.org/supabase)*
- `node <script>` *(fails: ENETUNREACH trying to reach https://vvswuuysqxyfxfspmqda.supabase.co)*

------
https://chatgpt.com/codex/tasks/task_e_68b18c6db0408330b0573f7fb17ff578